### PR TITLE
Fix bug with font tags in chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parchment",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.7.zenreach",
   "description": "A document model for rich text editors",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com/docs/parchment",

--- a/src/blot/abstract/container.ts
+++ b/src/blot/abstract/container.ts
@@ -193,6 +193,7 @@ class ContainerBlot extends ShadowBlot implements Parent {
       let blot;
       if (node instanceof HTMLFontElement) {
         // node is in the form <font><span><b>...</b></span></font>
+        // Registry.create doesn't handle the <font> case well, and throws a ParchmentError
         const BlotClass = <Registry.BlotConstructor>Registry.query(node.firstChild.firstChild);
         blot = new BlotClass(node.firstChild.firstChild);
       } else {

--- a/src/blot/abstract/container.ts
+++ b/src/blot/abstract/container.ts
@@ -192,6 +192,7 @@ class ContainerBlot extends ShadowBlot implements Parent {
       }
       let blot;
       if (node instanceof HTMLFontElement) {
+        // node is in the form <font><span><b>...</b></span></font>
         const BlotClass = <Registry.BlotConstructor>Registry.query(node.firstChild.firstChild);
         blot = new BlotClass(node.firstChild.firstChild);
       } else {

--- a/src/blot/abstract/container.ts
+++ b/src/blot/abstract/container.ts
@@ -190,7 +190,13 @@ class ContainerBlot extends ShadowBlot implements Parent {
       if (node.nextSibling != null) {
         refBlot = Registry.find(node.nextSibling);
       }
-      let blot = Registry.find(node) || Registry.create(node);
+      let blot;
+      if (node instanceof HTMLFontElement) {
+        const BlotClass = <Registry.BlotConstructor>Registry.query(node.firstChild.firstChild);
+        blot = new BlotClass(node.firstChild.firstChild);
+      } else {
+        blot = Registry.find(node) || Registry.create(node);
+      }
       if (blot.next != refBlot || blot.next == null) {
         if (blot.parent != null) {
           blot.parent.children.remove(blot);


### PR DESCRIPTION
This pull request is related to the following trello card: https://trello.com/c/OQYYcv8m/18-5-quill-fixes-4
It fixes (in a hacky way) the issue that I filed here: quilljs/quill#783. The decision to fork parchment was made after a lot of consideration - We need to fork Parchment because the handling code for mutations in the DOM is located inside Parchment. There may be a way to fix it in Quill that is more high-level, but after a lot of digging into, I can't figure it out in a reasonable amount of time, and I have simply filed an issue on the main Quill repo. This PR will fix the bug for our product, and should Quill release a bugfix later on, we can point back to the original Parchment.
